### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go_build.yml
+++ b/.github/workflows/go_build.yml
@@ -3,6 +3,9 @@
 
 name: Go Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/SmilingPixel/rest_trace_fuzzer/security/code-scanning/1](https://github.com/SmilingPixel/rest_trace_fuzzer/security/code-scanning/1)

To fix the problem, we should add a `permissions` block to the workflow to restrict the permissions of the GITHUB_TOKEN. Since the workflow only checks out code and builds it, it only needs read access to repository contents. The best way to fix this is to add a `permissions` block at the root level of the workflow (before the `jobs:` key), setting `contents: read`. This will apply to all jobs in the workflow unless overridden. No additional imports or definitions are needed; this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
